### PR TITLE
Swagger Documentation Initialised

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -54,6 +54,7 @@ DJANGO_APPS = [
     # "django.contrib.humanize", # Handy template tags
     "django.contrib.admin",
     "django.forms",
+    "rest_framework_swagger",
 ]
 THIRD_PARTY_APPS = [
     "crispy_forms",
@@ -204,5 +205,15 @@ MANAGERS = ADMINS
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = "/static/"
+
+REST_FRAMEWORK = {
+    # Parser classes priority-wise for Swagger
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser',
+        'rest_framework.parsers.JSONParser',
+    ],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
+}
 
 django_heroku.settings(locals())

--- a/config/settings.py
+++ b/config/settings.py
@@ -54,7 +54,6 @@ DJANGO_APPS = [
     # "django.contrib.humanize", # Handy template tags
     "django.contrib.admin",
     "django.forms",
-    "rest_framework_swagger",
 ]
 THIRD_PARTY_APPS = [
     "crispy_forms",
@@ -63,6 +62,7 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount",
     "rest_framework",
     "rest_framework.authtoken",
+    "drf_yasg"
 ]
 
 LOCAL_APPS = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,6 +5,11 @@ from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
 from rest_framework.authtoken.views import obtain_auth_token
+from django.conf.urls import url, include
+
+from rest_framework_swagger.views import get_swagger_view
+schema_view = get_swagger_view(title='Swagger API Documentation')
+
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
@@ -25,6 +30,7 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("auth-token/", obtain_auth_token),
+    url(r'^swagger/', schema_view),
 ]
 
 if settings.DEBUG:

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,8 +7,18 @@ from django.views.generic import TemplateView
 from rest_framework.authtoken.views import obtain_auth_token
 from django.conf.urls import url, include
 
-from rest_framework_swagger.views import get_swagger_view
-schema_view = get_swagger_view(title='Swagger API Documentation')
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+        title="Civic Tech Index API Documentation",
+        default_version='v1',
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 
 urlpatterns = [
@@ -30,7 +40,7 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("auth-token/", obtain_auth_token),
-    url(r'^swagger/', schema_view),
+    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]
 
 if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,9 +33,9 @@ django-extensions==2.2.9
 django-heroku==0.3.1
 django-model-utils==4.0.0
 django-redis==4.11.0
-django-rest-swagger==2.2.0
 django-storages==1.9.1
 django-stubs==1.5.0
+djangorestframework==3.11.0
 docutils==0.15.2
 drf-yasg==1.17.1
 entrypoints==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ cffi==1.14.0
 cfgv==3.1.0
 chardet==3.0.4
 click==7.1.2
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==5.1
 decorator==4.4.2
 defusedxml==0.6.0
@@ -31,6 +33,7 @@ django-extensions==2.2.9
 django-heroku==0.3.1
 django-model-utils==4.0.0
 django-redis==4.11.0
+django-rest-swagger==2.2.0
 django-storages==1.9.1
 django-stubs==1.5.0
 djangorestframework==3.11.0
@@ -46,10 +49,12 @@ identify==1.4.20
 idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.6.1
+inflection==0.5.1
 ipdb==0.13.2
 ipython==7.15.0
 ipython-genutils==0.2.0
 isort==4.3.21
+itypes==1.2.0
 jedi==0.17.1
 Jinja2==2.11.2
 jmespath==0.10.0
@@ -61,6 +66,7 @@ mypy==0.770
 mypy-extensions==0.4.3
 nodeenv==1.4.0
 oauthlib==3.1.0
+openapi-codec==1.3.2
 packaging==20.4
 parso==0.7.0
 pathspec==0.8.0
@@ -93,7 +99,10 @@ redis==3.5.0
 regex==2020.6.8
 requests==2.24.0
 requests-oauthlib==1.3.0
+ruamel.yaml==0.16.10
+ruamel.yaml.clib==0.2.0
 s3transfer==0.3.3
+simplejson==3.17.2
 six==1.15.0
 snowballstemmer==2.0.0
 Sphinx==3.0.3
@@ -110,6 +119,7 @@ toml==0.10.1
 traitlets==4.3.3
 typed-ast==1.4.1
 typing-extensions==3.7.4.2
+uritemplate==3.0.1
 urllib3==1.25.9
 virtualenv==20.0.24
 wcwidth==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,8 @@ django-redis==4.11.0
 django-rest-swagger==2.2.0
 django-storages==1.9.1
 django-stubs==1.5.0
-djangorestframework==3.11.0
 docutils==0.15.2
+drf-yasg==1.17.1
 entrypoints==0.3
 factory-boy==2.12.0
 Faker==4.1.1


### PR DESCRIPTION
- Using [drf-yasg](https://drf-yasg.readthedocs.io/en/stable/index.html) as [Django-REST-Swagger](https://github.com/marcgibbons/django-rest-swagger) is deprecated and has an issue in the index.html page for python v3.7 
- Deployed this branch on heroku: https://test-civictechindexadmin.herokuapp.com/swagger with the existing set of APIs
