### PR TITLE
Split serializer for lists of orgs vs org detail

### DIFF
--- a/civictechindexadmin/data/api/serializers.py
+++ b/civictechindexadmin/data/api/serializers.py
@@ -39,18 +39,28 @@ class OrganizationFullSerializer(serializers.ModelSerializer):
     links = LinkSerializer(many=True, read_only=True)
     aliases = serializers.SerializerMethodField()
     affiliated = serializers.SerializerMethodField()
+    parents = serializers.SerializerMethodField()
+    children = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
         fields = ['id', 'depth', 'path', 'name', 'slug', 'github_name', 'github_id',
                   'cti_contributor', 'city', 'state', 'country', 'image_url', 'org_tag',
-                  'links', 'aliases', 'affiliated', ]
+                  'links', 'aliases', 'affiliated', 'parents', 'children', ]
 
     def get_aliases(self, org):
         return [a.alias for a in Alias.objects.filter(tag=org.org_tag).all()]
 
     def get_affiliated(self, org):
         return not (org.depth == 2 and org.numchild == 0)
+
+    def get_parents(self, org):
+        parents = org.get_ancestors()
+        return [{'slug': n.slug, 'name': n.name, 'image_url': n.image_url} for n in parents if n.depth > 1]
+
+    def get_children(self, org):
+        children = org.get_descendants()
+        return [{'slug': n.slug, 'name': n.name, 'image_url': n.image_url} for n in children if n.depth > 1]
 
 
 class AddOrganizationSerializer(serializers.Serializer):

--- a/civictechindexadmin/data/api/serializers.py
+++ b/civictechindexadmin/data/api/serializers.py
@@ -17,12 +17,13 @@ class LinkSerializer(serializers.ModelSerializer):
 
 class OrganizationSerializer(serializers.ModelSerializer):
     affiliated = serializers.SerializerMethodField()
+    links = LinkSerializer(many=True, read_only=True)
 
     class Meta:
         model = Organization
         fields = ['id', 'depth', 'path', 'name', 'slug', 'github_name', 'github_id',
                   'cti_contributor', 'city', 'state', 'country', 'image_url', 'org_tag',
-                  'affiliated', ]
+                  'affiliated', 'links', ]
 
     def get_affiliated(self, org):
         return not (org.depth == 2 and org.numchild == 0)

--- a/civictechindexadmin/data/api/views.py
+++ b/civictechindexadmin/data/api/views.py
@@ -35,7 +35,7 @@ class OrganizationViewSet(GenericViewSet):
         Items are returned as a tree - ordered alphabetically within their level.
         """
         results = self.filter_queryset(self.get_queryset())
-        serializer = OrganizationFullSerializer(results, many=True)
+        serializer = OrganizationSerializer(results, many=True)
         return Response(serializer.data)
 
     @swagger_auto_schema(responses={200: OrganizationFullSerializer()})

--- a/civictechindexadmin/data/api/views.py
+++ b/civictechindexadmin/data/api/views.py
@@ -22,6 +22,7 @@ class OrganizationViewSet(GenericViewSet):
     queryset = Organization.objects.filter(status='approved', depth__gt=1).prefetch_related('links')
     serializer_class = OrganizationSerializer
     filter_backends = [SearchFilter]
+    lookup_field = 'slug'
     search_fields = ['@name', '@city', '@state', '@country']
 
     @swagger_auto_schema(responses={200: OrganizationSerializer(many=True)})
@@ -38,15 +39,14 @@ class OrganizationViewSet(GenericViewSet):
         return Response(serializer.data)
 
     @swagger_auto_schema(responses={200: OrganizationFullSerializer()})
-    def retrieve(self, request, pk=None):
+    def retrieve(self, request, slug=None):
         """
-        Returns all the information we know about a single organization.
-        The current version uses the organization's name as the lookup key
-        but we may want to change that to use a sluggified version of the name.
+        Returns all the information we know about a single organization -
+        using the slug as the lookup field
         """
-        org = Organization.objects.filter(slug=pk, status='approved').prefetch_related('links').first()
+        org = Organization.objects.filter(slug=slug, status='approved').prefetch_related('links').first()
         if not org:
-            raise NotFound(f"No organization by the name of '{pk}'")
+            raise NotFound(f"No organization '{slug}'")
         serializer = OrganizationFullSerializer(org)
         return Response(serializer.data)
 

--- a/civictechindexadmin/data/api/views.py
+++ b/civictechindexadmin/data/api/views.py
@@ -35,7 +35,7 @@ class OrganizationViewSet(GenericViewSet):
         Items are returned as a tree - ordered alphabetically within their level.
         """
         results = self.filter_queryset(self.get_queryset())
-        serializer = OrganizationSerializer(results, many=True)
+        serializer = OrganizationSerializer(results, many=True, context={'request': request})
         return Response(serializer.data)
 
     @swagger_auto_schema(responses={200: OrganizationFullSerializer()})

--- a/civictechindexadmin/data/tests/factories.py
+++ b/civictechindexadmin/data/tests/factories.py
@@ -35,8 +35,8 @@ class OrganizationFactory(DjangoModelFactory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Override the default ``_create``to incorporate add_child."""
-        if 'parent' in kwargs.values():
-            parent = kwargs['parent']
+        if 'parent' in kwargs.keys():
+            parent = kwargs.pop('parent')
         elif model_class.get_first_root_node():
             parent = model_class.get_first_root_node()
         else:

--- a/civictechindexadmin/data/tests/test_organization_api.py
+++ b/civictechindexadmin/data/tests/test_organization_api.py
@@ -106,6 +106,27 @@ def test_get_organization_detail_includes_aliases(api_client):
     assert sorted(data['aliases']) == ['code4somewhere', 'codeforsomewhere']
 
 
+def test_get_organization_detail_includes_parents(api_client):
+    parent_org = OrganizationFactory(org_tag='code-for-everywhere')
+    org = OrganizationFactory(org_tag='code-for-somewhere', parent=parent_org)
+    data = _get_org_detail_page(api_client, org)
+    assert data['name'] == org.name
+    assert data['org_tag'] == org.org_tag
+    assert len(data['parents']) == 1
+    assert data['parents'][0]['slug'] == parent_org.slug
+
+
+def test_get_organization_detail_includes_children(api_client):
+    org = OrganizationFactory(org_tag='code-for-everywhere')
+    child = OrganizationFactory(org_tag='code-for-somewhere', parent=org)
+    data = _get_org_detail_page(api_client, org)
+    assert data['name'] == org.name
+    assert data['org_tag'] == org.org_tag
+    assert data['parents'] == []
+    assert len(data['children']) == 1
+    assert data['children'][0]['slug'] == child.slug
+
+
 def test_create_organization_required_fields(api_client):
     url = '/api/organizations/'
     response = api_client.post(url, {})

--- a/civictechindexadmin/data/tests/test_organization_api.py
+++ b/civictechindexadmin/data/tests/test_organization_api.py
@@ -61,11 +61,11 @@ def test_get_org_detail_does_not_show_submitted(api_client):
 
 
 def test_get_org_detail_does_not_show_denied(api_client):
-    org = OrganizationFactory(name='Evil', status='denied')
+    org = OrganizationFactory(name='Evil Empire', status='denied')
     url = f'/api/organizations/{org.slug}/'
     response = api_client.get(url)
     assert response.status_code == 404
-    assert response.json()['detail'] == "No organization by the name of 'evil'"
+    assert response.json()['detail'] == "No organization 'evil-empire'"
 
 
 def test_get_organization_by_github_id(api_client):


### PR DESCRIPTION
And now that we are again using different serializers for what is returned from the list view vs the detail view, added a minimal representation of parents and children to the organization detail output.