### PR TITLE
Try fixing swagger when run in AWS

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -25,6 +25,7 @@ INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
 INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Our AWS install only serves pages on https so we need Django to know that is the
appropriate protocol - even though the ELB has forwarded the request unencrypted.