### PR TITLE
Allow AddOrganizationSerializer to take a parent org name

### DIFF
--- a/civictechindexadmin/data/api/views.py
+++ b/civictechindexadmin/data/api/views.py
@@ -61,7 +61,13 @@ class OrganizationViewSet(GenericViewSet):
         serializer = AddOrganizationSerializer(data=request.data)
         if serializer.is_valid():
             new_org = serializer.create()
-            return Response(OrganizationFullSerializer(new_org).data, status=status.HTTP_201_CREATED)
+            data = OrganizationFullSerializer(new_org).data
+            # If we added this to an existing parent org, return the parent org name
+            if new_org.depth == 2:
+                data['parent_organization_name'] = request.data.get("parent_organization_name", '')
+            else:
+                data['parent_organization_name'] = data['parents'][0]['name']
+            return Response(data, status=status.HTTP_201_CREATED)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
This is in response to https://github.com/civictechindex/CTI-website-frontend/issues/693 

I need a front end person to evaluate if this fixes that issue or not. 

It was easiest for me to keep the current input field named `parent_organization` and add `parent_organization_name` for the new string field. 

The returned data always returns "parent_organization_name" regardless of how we get the information for the parent.