### PR TITLE
Requirements - Update django to LTS 3.1 was EOL'd 4 months ago. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.5.0
-Django==3.1.13
+Django==3.2.13
 django-allauth==0.44.0
 django-anymail==8.2
 django-cors-headers==3.7.0
@@ -7,7 +7,7 @@ django-coverage-plugin==1.8.0
 django-crispy-forms==1.11.2
 django-environ==0.4.5
 django-heroku==0.3.1
-djangorestframework==3.12.4
+djangorestframework==3.13.1
 django-treebeard==4.5.1
 drf-yasg==1.20.0
 gunicorn==20.1.0


### PR DESCRIPTION
Django 3.1 was end of lifed a the start of 2022 bumping to 3.2 which is an LTS
DRF is just an update to latest feature upgrade

All tests passed.  Seemed like it might be a good idea to get this in the wild well before going live.